### PR TITLE
Sample code for adding a db config dynamically

### DIFF
--- a/tenant_management/app/controllers/tenant.py
+++ b/tenant_management/app/controllers/tenant.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core import management
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.pagination import LimitOffsetPagination
@@ -61,7 +62,7 @@ class AddDatabaseClientDBAPI(APIView):
         DB_NAME = "db_five"
         configs = {
             "ENGINE": "django.db.backends.postgresql",
-            "HOST": "postgres1",
+            "HOST": "postgres5",
             "PORT": 5432,
             "NAME": "tenant_management",
             "USER": "ygFevkWspveZyQtiWLKAZeUTnDUzQ",
@@ -75,7 +76,10 @@ class AddDatabaseClientDBAPI(APIView):
             "TEST": {"CHARSET": None, "COLLATION": None, "MIGRATE": True, "MIRROR": None, "NAME": None},
         }
         settings.DATABASES[DB_NAME] = configs
+        print("Calling the migrate command")
+        management.call_command("migrate", app_label="app", database=DB_NAME)
+
         print("======================================================")
         print("Successfully set db_five config in the settings.DATABASES")
         print("======================================================")
-        return Response({"status": "success", "response": {}, "message": "Added new DB successfully"})
+        return Response({"status": "success", "response": settings.DATABASES, "message": "Added new DB successfully"})

--- a/tenant_management/app/controllers/tenant.py
+++ b/tenant_management/app/controllers/tenant.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.pagination import LimitOffsetPagination
@@ -49,3 +50,32 @@ class TenantRetrieveUpdateDeleteAPIView(APIView):
         tenant = get_object_or_404(Tenant, pk=pk)
         tenant.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class AddDatabaseClientDBAPI(APIView):
+    @staticmethod
+    def get(request):
+        print("======================================================")
+        print("Setting the db_five in the settings.DATABASES")
+        print("======================================================")
+        DB_NAME = "db_five"
+        configs = {
+            "ENGINE": "django.db.backends.postgresql",
+            "HOST": "postgres1",
+            "PORT": 5432,
+            "NAME": "tenant_management",
+            "USER": "ygFevkWspveZyQtiWLKAZeUTnDUzQ",
+            "PASSWORD": "XJf9ErJYGv2cbaOytXvsdFZKxiMsVTl1JtnvO0HkePxPhbvVfYlXQc7xIu",
+            "ATOMIC_REQUESTS": False,
+            "AUTOCOMMIT": True,
+            "CONN_HEALTH_CHECKS": False,
+            "CONN_MAX_AGE": 0,
+            "TIME_ZONE": None,
+            "OPTIONS": {},
+            "TEST": {"CHARSET": None, "COLLATION": None, "MIGRATE": True, "MIRROR": None, "NAME": None},
+        }
+        settings.DATABASES[DB_NAME] = configs
+        print("======================================================")
+        print("Successfully set db_five config in the settings.DATABASES")
+        print("======================================================")
+        return Response({"status": "success", "response": {}, "message": "Added new DB successfully"})

--- a/tenant_management/app/tests/tenant.py
+++ b/tenant_management/app/tests/tenant.py
@@ -44,9 +44,7 @@ class TenantAPITestCase(APITestCase):
         self.assertEqual(response.data["first_name"], "Bob")
 
     def test_update_tenant(self):
-        tenant = Tenant.objects.create(
-            first_name="Charlie", last_name="Brown", email="charlie@gmail.com"
-        )
+        tenant = Tenant.objects.create(first_name="Charlie", last_name="Brown", email="charlie@gmail.com")
         url = reverse("tenant", args=[tenant.id])
         updated_data = {"first_name": "David", "last_name": "Smith", "email": "david@gmail.com"}
         response = self.client.put(url, updated_data, format="json")

--- a/tenant_management/settings.py
+++ b/tenant_management/settings.py
@@ -122,14 +122,6 @@ DATABASES = {
         "HOST": "postgres4",
         "PORT": env("POSTGRES_PORT"),
     },
-    "db_five": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": env("POSTGRES_DB"),
-        "USER": env("POSTGRES_USER"),
-        "PASSWORD": env("POSTGRES_PASSWORD"),
-        "HOST": "postgres5",
-        "PORT": env("POSTGRES_PORT"),
-    },
 }
 
 # Password validation

--- a/tenant_management/urls.py
+++ b/tenant_management/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("admin/", admin.site.urls),
     # Custom views
+    path("api/v1.0/add_tenant_db/", tenant_views.AddDatabaseClientDBAPI.as_view(), name="add_tenant_db"),
     path("api/v1.0/tenants/", tenant_views.TenantListCreateAPIView.as_view(), name="tenants"),
     path("api/v1.0/tenants/<int:pk>", tenant_views.TenantRetrieveUpdateDeleteAPIView.as_view(), name="tenant"),
     # OpenAPI - Swagger


### PR DESCRIPTION
Steps to add a new DB config - 
1. Make sure the DB does not exist beforehand - make a request with appropriate headers to add data to the non-existent db.
2. The request should fail stating that the DB does not exist.
3. Use the code in the API to add a new DB config to the settings; also update the tenant_map to have an entry for the new DB.
4. Once added, again make the same request from step 1 - it should give a success response now.