### PR TITLE
feat: dynamic schema name

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,4 +4,4 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput
 python /app/manage.py migrate
-/usr/local/bin/gunicorn tenant_management.wsgi --bind 0.0.0.0:8000 --chdir=/app
+python /app/manage.py runserver 0.0.0.0:8000

--- a/tenant_management/app/controllers/tenant.py
+++ b/tenant_management/app/controllers/tenant.py
@@ -1,3 +1,4 @@
+from django.core.management import call_command
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.pagination import LimitOffsetPagination
@@ -6,26 +7,43 @@ from rest_framework.views import APIView
 
 from tenant_management.app.models.employee import Employee
 from tenant_management.app.serializers.tenant import TenantSerializer
+from tenant_management.app.utils.middlewares import set_custom_schema
 
 
 class EmployeeListCreateAPIView(APIView, LimitOffsetPagination):
     def get(self, request):
-        tenants_qs = Employee.objects.all()
-        page = self.paginate_queryset(tenants_qs, request, view=self)
-        if page is not None:
-            serializer = TenantSerializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-        # Return all the items
-        serializer = TenantSerializer(tenants_qs, many=True)
-        return Response(serializer.data)
+        final_result = []
+
+        # Set schema to Rohit
+        set_custom_schema(request, "rohit")
+        rohit_qs = Employee.objects.all()
+        final_result.append(TenantSerializer(rohit_qs, many=True).data)
+
+        # Set schema to Abhishek
+        set_custom_schema(request, "abhi")
+        abhishek_qs = Employee.objects.all()
+        final_result.append(TenantSerializer(abhishek_qs, many=True).data)
+
+        # Set schema to Rohit
+        set_custom_schema(request, "rohit")
+        rohit_qs = Employee.objects.all()
+        final_result.append(TenantSerializer(rohit_qs, many=True).data)
+
+        return Response(final_result)
 
     @staticmethod
     def post(request):
-        serializer = TenantSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        set_custom_schema(request, "public")
+        name = "rohitd"
+        call_command(
+            "create_tenant",
+            verbosity=0,
+            interactive=False,
+            schema_name=f"{name}",
+            domain_domain=f"{name}.com",
+            name=f"{name}",
+        )
+        return Response({"status": "success"}, status=status.HTTP_201_CREATED)
 
 
 class TenantRetrieveUpdateDeleteAPIView(APIView):

--- a/tenant_management/app/utils/middlewares.py
+++ b/tenant_management/app/utils/middlewares.py
@@ -3,6 +3,13 @@ from django_tenants.middleware import TenantMainMiddleware
 from django_tenants.postgresql_backend.base import FakeTenant
 
 
+def set_custom_schema(request, schema_name):
+    tenant = FakeTenant(tenant_type=None, schema_name=schema_name)
+    tenant.domain_url = schema_name
+    request.tenant = tenant
+    connection.set_tenant(request.tenant)
+
+
 class CustomMiddleware(TenantMainMiddleware):
     @staticmethod
     def hostname_from_request(request):


### PR DESCRIPTION
* Added method to update the schema in runtime `set_custom_schema`
* Updated GET endpoint to fetch from multiple schemas 

Experiment: 
Created two tenants -- rohit and abhi. Only abhi had a record in the db.

Expected result:
![image](https://github.com/rohit-clootrack/tenant-poc/assets/111347836/d2edefa4-2977-44df-a604-587a3dea63cf)


